### PR TITLE
Reordered requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch>=1.7
-numpy<1.21
+numpy<1.21  # numba requires numpy<1.21,>=1.17
 opencv-python
 torchvision
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
+torch>=1.7
+numpy<1.21
+opencv-python
+torchvision
+scipy
+tqdm
 basicsr>=1.3.3.10
 facexlib>=0.2.0.2
 lmdb
-numpy
-opencv-python
 pyyaml
 tb-nightly
-torch>=1.7
-torchvision
-tqdm
 yapf

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ opencv-python
 torchvision
 scipy
 tqdm
-basicsr>=1.3.3.10
-facexlib>=0.2.0.2
+basicsr>=1.3.4.0
+facexlib>=0.2.0.3
 lmdb
 pyyaml
 tb-nightly


### PR DESCRIPTION
It had the wrong order, resulting in `basicsr` not wanting to install.