### PR TITLE
[bug fix] No module named 'gfpgan.version'

### DIFF
--- a/gfpgan/__init__.py
+++ b/gfpgan/__init__.py
@@ -3,4 +3,4 @@ from .archs import *
 from .data import *
 from .models import *
 from .utils import *
-from .version import *
+# from .version import *


### PR DESCRIPTION
The following error occurred when I tried to run the script with Pythone3, I simply removed this line `from .version import *` at `gfpgan/__init__.py`, and the problem fixed
```
File "/Users/Desktop/GFPGAN/inference_gfpgan.py", line 9, in <module>
    from gfpgan import GFPGANer
  File "/Users/Desktop/GFPGAN/gfpgan/__init__.py", line 6, in <module>
    from .version import *
ModuleNotFoundError: No module named 'gfpgan.version'
```

### Machine: Mac
### CPU: Intel
### macOS: Monterey 12.1

### Python: 3.x

### Occurs with:
```python3 inference_gfpgan.py --upscale 2 --test_path inputs/whole_imgs --save_root results```