### PR TITLE
Fix basicsr losses import

### DIFF
--- a/gfpgan/models/gfpgan_model.py
+++ b/gfpgan/models/gfpgan_model.py
@@ -3,7 +3,7 @@ import os.path as osp
 import torch
 from basicsr.archs import build_network
 from basicsr.losses import build_loss
-from basicsr.losses.losses import r1_penalty
+from basicsr.losses.gan_loss import r1_penalty
 from basicsr.metrics import calculate_metric
 from basicsr.models.base_model import BaseModel
 from basicsr.utils import get_root_logger, imwrite, tensor2img


### PR DESCRIPTION
With the most recent 1.4.0 release of BasicSR (https://github.com/XPixelGroup/BasicSR/releases), some basicSR module imports in GFPGAN may have to be reconfigured as some of the changes include updates to some directories such as the basicsr.losses directory. 
The only error I came across was in the gfpgan_model.py module, where I had to change "from basicsr.losses.losses import r1_penalty" to "from basicsr.losses.gan_loss import r1_penalty". This was the only import error that occurred during execution of my script but there may be several other module imports that may have to be double checked. 