### PR TITLE
fix: use tensorboard instead of tb-nightly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy
 opencv-python
 pyyaml
 scipy
-tb-nightly
+tensorboard
 torch>=1.7
 torchvision
 tqdm


### PR DESCRIPTION

it is not a good idea to list tb-nightly as a dependency. Instead it's better to use the stable version of tensorboard. This will make the pip installation of this package easier.