### PR TITLE
basicsr version update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-basicsr>=1.4.2
+basicsr>=1.3.3.5
 facexlib>=0.2.5
 lmdb
 numpy


### PR DESCRIPTION
There was a version class becasue of from torchvision.transforms_functional import rgb_to_grayscale to from torchvision.transforms.functional import rgb_to_grayscale which in the lastest version have changed.