### PR TITLE
Fix Python 3.13 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = [
+    "basicsr", "facexlib", "lmdb", "numpy", "opencv-python", "pyyaml",
+    "scipy", "tb-nightly", "torch", "torchvision", "tqdm", "yapf", "cython"
+]
+build-backend = "setuptools.build_meta"
+packages = ["gfpgan"]
+
+[project]
+name = "gfpgan"
+version = "1.3.8"
+authors = [
+  { name="Xintao Wang", email="xintao.wang@outlook.com" },
+]
+description = "GFPGAN aims at developing Practical Algorithms for Real-world Face Restoration"
+readme = "README.md"
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+license = {text = "Apache-2.0"}
+
+[project.urls]
+Homepage = "github.com/Disty0/GFPGAN"
+Issues = "https://github.com/TencentARC/GFPGAN/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,5 @@
 [build-system]
-requires = [
-    "basicsr", "facexlib", "lmdb", "numpy", "opencv-python", "pyyaml",
-    "scipy", "tb-nightly", "torch", "torchvision", "tqdm", "yapf", "cython"
-]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 packages = ["gfpgan"]
 
@@ -20,6 +17,11 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 license = {text = "Apache-2.0"}
+
+dependencies = [
+    "basicsr", "facexlib", "lmdb", "numpy", "opencv-python", "pyyaml",
+    "scipy", "tb-nightly", "torch", "torchvision", "tqdm", "yapf", "cython"
+]
 
 [project.urls]
 Homepage = "github.com/Disty0/GFPGAN"

--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,7 @@ version_info = ({})
 
 def get_version():
     with open(version_file, 'r') as f:
-        exec(compile(f.read(), version_file, 'exec'))
-    return locals()['__version__']
+        return f.read().split("'")[1]
 
 
 def get_requirements(filename='requirements.txt'):


### PR DESCRIPTION
Fixes Python 3.13 compatibility.  

exec doesn't update locals with Python 3.13.  
This PR parses the version file as a text instead of running exec.  

GFPGAN cannot be installed with Python 3.13 without this PR.  

Relevant issue from BasicSR repo is this: https://github.com/XPixelGroup/BasicSR/issues/725
Issue thread is from BasicSR but the issue and the trace is the same in GFPGAN.  